### PR TITLE
replaced get_barset with get_bars, test for positions fixed

### DIFF
--- a/cira/stock.py
+++ b/cira/stock.py
@@ -1,5 +1,6 @@
 # import alpaca_trade_api as tradeapi
 import datetime
+from alpaca_trade_api import TimeFrame
 from . import config
 from . import alpaca
 from . import logging
@@ -94,7 +95,7 @@ class Stock:
 
     def barset(self, limit:int):
         """ returns barset for stock for time period lim """
-        self._barset = alpaca.api().get_barset(self.symbol, "minute", limit=int(limit))[self.symbol]
+        self._barset = alpaca.api().get_bars(self.symbol, TimeFrame.Minute, limit=int(limit))
         return self._barset
 
 

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -48,7 +48,7 @@ def test_buy_sell(): # no assert !
     exchange = cira.Exchange()
     if exchange.is_open:
         stk = cira.Stock("PYPL")
-        stk.buy(1)
+        stk.buy(2)
         time.sleep(1)
         stk.sell(1)
 


### PR DESCRIPTION
-get_barset no longer exists, replaced by get_bars (requires import of TimeFrame)
-In tests, it appears that trying to get Position is failing due to buying then immediately selling test stock; to make a position request, I believe the stock needs to be held, so I changed the purchase amount to 2 shares (I know this is not elegant, maybe someone will have a better idea, just wanted to bring awareness to why tests were failing).

Thanks!
BD

